### PR TITLE
Plaintext channel builder patch by BanzaiCloud

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -88,6 +88,10 @@
       <allow pkg="org.apache.kafka.common.config" />
       <allow pkg="org.apache.kafka.common.metrics" />
       <allow pkg="org.apache.kafka.common.security" />
+      <allow pkg="org.apache.kafka.common.network.banzaicloud" />
+      <subpackage name="banzaicloud">
+        <allow pkg="org.apache.kafka.common.network" />
+      </subpackage>
     </subpackage>
 
     <subpackage name="resource">

--- a/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilders.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilders.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
+import org.apache.kafka.common.network.banzaicloud.PlaintextChannelWithOptionalUserIdentity;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.security.JaasContext;
 import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuilder;
@@ -137,7 +138,7 @@ public class ChannelBuilders {
                         time);
                 break;
             case PLAINTEXT:
-                channelBuilder = new PlaintextChannelBuilder(listenerName);
+                channelBuilder = new PlaintextChannelWithOptionalUserIdentity(listenerName);
                 break;
             default:
                 throw new IllegalArgumentException("Unexpected securityProtocol " + securityProtocol);

--- a/clients/src/main/java/org/apache/kafka/common/network/banzaicloud/PlaintextChannelWithOptionalUserIdentity.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/banzaicloud/PlaintextChannelWithOptionalUserIdentity.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.network.banzaicloud;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.memory.MemoryPool;
+import org.apache.kafka.common.network.Authenticator;
+import org.apache.kafka.common.network.ChannelBuilder;
+import org.apache.kafka.common.network.ChannelBuilders;
+import org.apache.kafka.common.network.KafkaChannel;
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.security.auth.banzaicloud.AuthenticationContextWithOptionalAuthId;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.KafkaPrincipalBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.SelectionKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ *
+ */
+public class PlaintextChannelWithOptionalUserIdentity implements ChannelBuilder {
+    private static final Logger log = LoggerFactory.getLogger(PlaintextChannelWithOptionalUserIdentity.class);
+    private final ListenerName listenerName;
+    private Map<String, ?> configs;
+
+    public PlaintextChannelWithOptionalUserIdentity(ListenerName listenerName) {
+        this.listenerName = listenerName;
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        this.configs = configs;
+    }
+
+    public KafkaChannel buildChannel(String id, SelectionKey key, int maxReceiveSize, MemoryPool memoryPool) throws KafkaException {
+        try {
+            ReadBufferedPlaintextTransportLayer transportLayer = new ReadBufferedPlaintextTransportLayer(key);
+            Supplier<Authenticator> authenticatorCreator = () -> new PrefixLookupAuthenticator(configs, transportLayer, listenerName);
+            return new KafkaChannel(id, transportLayer, authenticatorCreator, maxReceiveSize,
+                    memoryPool != null ? memoryPool : MemoryPool.NONE);
+        } catch (Exception e) {
+            log.warn("Failed to create channel due to ", e);
+            throw new KafkaException(e);
+        }
+    }
+
+    /**
+     * A basic authenticator implementation which differs from
+     * {@link org.apache.kafka.common.network.PlaintextChannelBuilder.PlaintextAuthenticator}
+     * in only a few parts. It implements {@link PrefixLookupAuthenticator ::authenticate} as a pre-processor of
+     * data received right after a connection was established with broker.
+     * The {@link PrefixLookupAuthenticator ::complete} method indicates the above mentioned process' state.
+     *
+     */
+    private static class PrefixLookupAuthenticator implements Authenticator {
+        private final static Logger log = LoggerFactory.getLogger(PrefixLookupAuthenticator.class);
+        private final static String BZC_PREFIX = "BZC_UID:";
+        private final static byte BZC_PKG_SIZE = 2;
+
+        private final ReadBufferedPlaintextTransportLayer transportLayer;
+        private final KafkaPrincipalBuilder principalBuilder;
+        private final ListenerName listenerName;
+
+
+        private volatile String authorizationId;
+        private ByteBuffer buffer;
+        private boolean limiterOk;
+        private int limiter;
+
+        public PrefixLookupAuthenticator(Map<String, ?> configs, ReadBufferedPlaintextTransportLayer transportLayer, ListenerName listenerName) {
+            this.transportLayer = transportLayer;
+            this.principalBuilder = ChannelBuilders.createPrincipalBuilder(configs, transportLayer, this, null, null);
+            this.listenerName = listenerName;
+        }
+
+        /**
+         * piggyback on the transport layer and handle the 1st message as an authorization id
+         * @throws IOException - network layer errors
+         */
+        @Override
+        synchronized public void authenticate() throws IOException {
+            if (authorizationId != null) {
+                log.info("Already authenticated");
+                return;
+            }
+
+            if (limiterOk) {
+                log.info("Authenticating: phase[2/2]");
+                buffer = ByteBuffer.allocate(limiter);
+                log.debug("Buffer allocated for payload with size: " + limiter);
+                transportLayer.read(buffer);
+                buffer.flip();
+                buffer.position(BZC_PKG_SIZE);
+                byte[] payload = new byte[buffer.remaining()];
+                buffer.get(payload, 0, buffer.remaining());
+                String text = new String(payload, StandardCharsets.UTF_8);
+                log.debug("Received payload message: " + text);
+
+                if (hasBZCPrefix(text)) {
+                    log.info("BZC prefix: present");
+                    authorizationId = extractAuthId(text);
+                    transportLayer.setPos(limiter);
+                } else {
+                    log.info("BZC prefix: not present");
+                    authorizationId = KafkaPrincipal.ANONYMOUS.getName();
+                }
+                transportLayer.authenticationDone();
+            } else {
+                log.info("Authenticating: phase[1/2]");
+                if (buffer == null) {
+                    log.debug("Buffer allocated with size: " + BZC_PKG_SIZE);
+                    buffer = ByteBuffer.allocate(BZC_PKG_SIZE);
+                }
+
+                log.debug("Reading network to get payload length");
+                transportLayer.read(buffer);
+
+                buffer.flip();
+                log.trace("buffer {}", new ReadBufferedPlaintextTransportLayer.BufferDetails(buffer));
+
+                if (buffer.remaining() > 0) {
+                    limiter = buffer.getShort(0) + BZC_PKG_SIZE;
+                    limiterOk = true;
+                    log.debug("Payload length present, len: " + limiter);
+                } else {
+                    log.debug("Payload length not present, went with anonymous");
+                    authorizationId = KafkaPrincipal.ANONYMOUS.getName();
+                    transportLayer.authenticationDone();
+                }
+            }
+            buffer = null;
+        }
+
+        @Override
+        public KafkaPrincipal principal() {
+            InetAddress clientAddress = transportLayer.socketChannel().socket().getInetAddress();
+
+            if (listenerName == null) {
+                throw new IllegalStateException("Unexpected call to principal() when listenerName is null");
+            }
+            if (authorizationId == null) {
+                throw new IllegalStateException("Unexpected call to principal() when authorizationId is null");
+            }
+
+            KafkaPrincipal kp = principalBuilder.build(new AuthenticationContextWithOptionalAuthId(
+                    clientAddress,
+                    listenerName.value(),
+                    authorizationId
+            ));
+            log.debug("KafkaPrincipal: " + kp);
+            return kp;
+        }
+
+        @Override
+        public boolean complete() {
+            if (authorizationId == null && transportLayer.isConnected()) {
+                try {
+                    authenticate();
+                } catch (IOException e) {
+                    return false;
+                }
+            }
+            return authorizationId != null;
+        }
+
+        @Override
+        public void close() {}
+
+        private String extractAuthId(String str) {
+            String[] result = str.split(BZC_PREFIX);
+            if (result.length == 2) {
+                log.debug("Extracted BZC postfix: " + result[1]);
+                return result[1];
+            }
+
+            log.warn(BZC_PREFIX + " prefixed id missing, went with anonymous");
+            return KafkaPrincipal.ANONYMOUS.getName();
+        }
+
+        private boolean hasBZCPrefix(String str) {
+            return str.startsWith(BZC_PREFIX);
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/network/banzaicloud/ReadBufferedPlaintextTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/banzaicloud/ReadBufferedPlaintextTransportLayer.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.network.banzaicloud;
+
+import org.apache.kafka.common.network.PlaintextTransportLayer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SelectionKey;
+
+/**
+ * Read buffered {@link PlaintextTransportLayer} to be able to push back on receiving buffer
+ */
+public class ReadBufferedPlaintextTransportLayer extends PlaintextTransportLayer {
+    private static final Logger log = LoggerFactory.getLogger(ReadBufferedPlaintextTransportLayer.class);
+    private static final int BUFF = 65536;
+    private ByteBuffer netReadBuffer;
+    private boolean authenticationDone;
+
+    public ReadBufferedPlaintextTransportLayer(SelectionKey key) throws IOException {
+        super(key);
+        netReadBuffer = ByteBuffer.allocate(BUFF);
+        authenticationDone = false;
+    }
+
+    /**
+     * No buffer shadowing needed
+     */
+    public void authenticationDone() {
+        authenticationDone = true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long read(ByteBuffer[] dsts, int offset, int length) throws IOException {
+        if ((offset < 0) || (length < 0) || (offset > dsts.length - length)) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        int totalRead = 0;
+        int i = offset;
+        while (i < length) {
+            if (dsts[i].hasRemaining()) {
+                int read = read(dsts[i]);
+                if (read > 0) {
+                    totalRead += read;
+                } else {
+                    break;
+                }
+            } else {
+                i++;
+            }
+        }
+        return totalRead;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long read(ByteBuffer[] dsts) throws IOException {
+        return read(dsts, 0, dsts.length);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        log.trace("dst: {}", new BufferDetails(dst));
+
+        int read = 0;
+        if (hasBytesBuffered()) {
+            read += readFromNetReadBuffer(dst);
+        }
+        log.trace("dst: {}", new BufferDetails(dst));
+
+        int netread = 0;
+        while (dst.hasRemaining()) {
+            if (netReadBuffer.hasRemaining()) {
+                netread = readSocket();
+                read += readFromNetReadBuffer(dst);
+            }
+
+            if (errOrNothing(netread)) {
+                break;
+            }
+        }
+        log.trace("dst: {}", new BufferDetails(dst));
+
+        if (netread < 0 && read == 0 && !hasBytesBuffered()) {
+            throw new EOFException("EOF during read");
+        }
+
+        log.trace("byte read: " + read);
+        return read;
+    }
+
+    private int readFromNetReadBuffer(ByteBuffer dst) {
+        ByteBuffer workOnBuffer = netReadBuffer;
+        if (!authenticationDone) {
+            workOnBuffer = netReadBuffer.duplicate();
+        }
+        workOnBuffer.flip();
+        int remaining = Math.min(workOnBuffer.remaining(), dst.remaining());
+        if (remaining > 0) {
+            int oldLimit = workOnBuffer.limit();
+            workOnBuffer.limit(workOnBuffer.position() + remaining);
+            dst.put(workOnBuffer);
+            workOnBuffer.limit(oldLimit);
+        }
+        if (authenticationDone) {
+            workOnBuffer.compact();
+        }
+        return remaining;
+    }
+
+    private int readSocket() throws IOException {
+        return socketChannel().read(netReadBuffer);
+    }
+
+    private boolean errOrNothing(int val) {
+        return val <= 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasBytesBuffered() {
+        return netReadBuffer.position() != 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() throws IOException {
+        netReadBuffer = null;
+        super.close();
+    }
+
+    /**
+     * Get rid of some bytes we don't need after authentication has finished
+     *
+     * @param pos the buffer position in front of we want to get rid of buffer's content
+     */
+    public void setPos(int pos) {
+        log.trace("net buffer: {}", new BufferDetails(netReadBuffer));
+
+        netReadBuffer.flip();
+        int oldLimit = netReadBuffer.limit();
+        netReadBuffer.limit(pos);
+        byte[] toDispose = new byte[pos];
+        netReadBuffer.get(toDispose, 0, pos);
+        netReadBuffer.limit(oldLimit);
+        netReadBuffer.compact();
+
+        log.trace("net buffer: {}", new BufferDetails(netReadBuffer));
+    }
+
+    /**
+     * Simple wrapper class to present basic buffer attributes
+     */
+    static class BufferDetails {
+        private final ByteBuffer bb;
+
+        BufferDetails(ByteBuffer byteBuffer) {
+            bb = byteBuffer;
+        }
+
+        @Override
+        public String toString() {
+            return  "pos: " + bb.position() +
+                    "limit: " + bb.limit() +
+                    "rem: " + bb.remaining() +
+                    "cap: " + bb.capacity();
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/security/auth/banzaicloud/AuthenticationContextWithOptionalAuthId.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/auth/banzaicloud/AuthenticationContextWithOptionalAuthId.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.auth.banzaicloud;
+
+import org.apache.kafka.common.security.auth.PlaintextAuthenticationContext;
+
+import java.net.InetAddress;
+
+/**
+ * To bypass authorization controllers which are not aware of banzai
+ * the class must be derived from {@link PlaintextAuthenticationContext}
+ */
+public class AuthenticationContextWithOptionalAuthId extends PlaintextAuthenticationContext {
+    private final String authorizationId;
+
+    public AuthenticationContextWithOptionalAuthId(InetAddress clientAddress, String listenerName, String authorizationId) {
+        super(clientAddress, listenerName);
+        this.authorizationId = authorizationId;
+    }
+
+    public String getAuthorizationId() {
+        return authorizationId;
+    }
+}
+

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/DefaultKafkaPrincipalBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/DefaultKafkaPrincipalBuilder.java
@@ -22,11 +22,12 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.network.Authenticator;
 import org.apache.kafka.common.network.TransportLayer;
 import org.apache.kafka.common.security.auth.AuthenticationContext;
-import org.apache.kafka.common.security.auth.KafkaPrincipal;
-import org.apache.kafka.common.security.auth.KafkaPrincipalBuilder;
+import org.apache.kafka.common.security.auth.banzaicloud.AuthenticationContextWithOptionalAuthId;
 import org.apache.kafka.common.security.auth.PlaintextAuthenticationContext;
 import org.apache.kafka.common.security.auth.SaslAuthenticationContext;
 import org.apache.kafka.common.security.auth.SslAuthenticationContext;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.KafkaPrincipalBuilder;
 import org.apache.kafka.common.security.kerberos.KerberosName;
 import org.apache.kafka.common.security.kerberos.KerberosShortNamer;
 
@@ -106,7 +107,10 @@ public class DefaultKafkaPrincipalBuilder implements KafkaPrincipalBuilder, Clos
 
     @Override
     public KafkaPrincipal build(AuthenticationContext context) {
-        if (context instanceof PlaintextAuthenticationContext) {
+        if (context instanceof AuthenticationContextWithOptionalAuthId) {
+            AuthenticationContextWithOptionalAuthId ctx = (AuthenticationContextWithOptionalAuthId) context;
+            return new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ctx.getAuthorizationId());
+        } else if (context instanceof PlaintextAuthenticationContext) {
             if (oldPrincipalBuilder != null)
                 return convertToKafkaPrincipal(oldPrincipalBuilder.buildPrincipal(transportLayer, authenticator));
 


### PR DESCRIPTION
*Custom transport layer built to enable to achieve a transparent way of authorization in which the application uses [CertificationRequestInfo](https://tools.ietf.org/html/rfc2986#section-4) fields to identify clients*

*All unit test both in clients and core module and Integration tests as well are OK*

